### PR TITLE
fix: webpack and vue configuration

### DIFF
--- a/ContentsColorPickerInput/rcms-js.config.js
+++ b/ContentsColorPickerInput/rcms-js.config.js
@@ -1,7 +1,7 @@
 module.exports = {
     name: 'ContentsEditSample',
     path: 'dist',
-    publicPath: '/files/user/js/mng_vue_components/',
+    publicPath: '/files/user/mng_vue_components',
 
     devHost: process.env.RCMS_JS_DEV_HOST || '127.0.0.1',
     devPort: process.env.RCMS_JS_DEV_PORT || 26787,

--- a/ContentsColorPickerInput/src/pages/ContentsColorPickerInput.vue
+++ b/ContentsColorPickerInput/src/pages/ContentsColorPickerInput.vue
@@ -7,6 +7,9 @@
     </td>
 </template>
 <script>
+import Vue from 'vue';
+window.rcmsJS.vue.registerVM(Vue, rcms_js_config.publicPath); // eslint-disable-line
+
 import { Chrome } from 'vue-color';
 export default {
     components: {
@@ -14,7 +17,6 @@ export default {
     },
     props: ['extConfig', 'test'],
     mounted: function() {
-        console.log(this.extConfig);
         this.colorCode = this.extConfig[0].value;
     },
     data() {

--- a/ContentsColorPickerInput/webpack.config.js
+++ b/ContentsColorPickerInput/webpack.config.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { DefinePlugin } = require('webpack');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const ManifestPlugin = require('webpack-manifest-plugin');
@@ -70,6 +71,9 @@ module.exports = {
     ],
   },
   plugins: [
+    new DefinePlugin({
+      rcms_js_config: JSON.stringify(config),
+    }),
     new VueLoaderPlugin(),
     new CleanWebpackPlugin(),
     new ManifestPlugin({ publicPath: '' }),

--- a/ContentsEditSample/rcms-js.config.js
+++ b/ContentsEditSample/rcms-js.config.js
@@ -1,7 +1,7 @@
 module.exports = {
     name: 'ContentsEditSample',
     path: 'dist',
-    publicPath: '/files/user/mng_vue_components/',
+    publicPath: '/files/user/mng_vue_components',
 
     devHost: process.env.RCMS_JS_DEV_HOST || '127.0.0.1',
     devPort: process.env.RCMS_JS_DEV_PORT || 26787,

--- a/ContentsEditSample/src/pages/ContentsEdit.vue
+++ b/ContentsEditSample/src/pages/ContentsEdit.vue
@@ -226,6 +226,9 @@
     </div>
 </template>
 <script>
+import Vue from 'vue';
+window.rcmsJS.vue.registerVM(Vue, rcms_js_config.publicPath); // eslint-disable-line
+
 import axios from 'axios';
 import config from '@/common/config';
 import Multiselect from 'vue-multiselect';

--- a/ContentsEditSample/webpack.config.js
+++ b/ContentsEditSample/webpack.config.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { DefinePlugin } = require('webpack');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const ManifestPlugin = require('webpack-manifest-plugin');
@@ -70,6 +71,9 @@ module.exports = {
     ],
   },
   plugins: [
+    new DefinePlugin({
+      rcms_js_config: JSON.stringify(config),
+    }),
     new VueLoaderPlugin(),
     new CleanWebpackPlugin(),
     new ManifestPlugin({ publicPath: '' }),


### PR DESCRIPTION
@nawa-diverta @takel-shiba 
I have added some configuration to the plugin sample.

Kuroco management page uses a common global Vue instance to output the templates.
The global Vue instance is prioritized over the original one by default, so users must add their Vue instance to `window.rcmsJS` in order to avoid conflicts.

For example, the following component outputs `PluginProp: undefined` instead of `PluginProp: VuePluginMixinText` if it's not registered in `window.rcmsJS`. This is because the user-defined Vue instance is overwritten by the global one.

```vue
<template>
    <div>PluginProp: {{ pluginProp || 'undefined' }}</div>
</template>
<script>
import Vue from 'vue';
// window.rcmsJS.vue.registerVM(Vue, rcms_js_config.publicPath); // eslint-disable-line
Vue.use({
    install: function(Vue) {
        Vue.mixin({
            props: {
                pluginProp: {
                    type: String,
                    default: 'VuePluginMixinText',
                },
            },
        });
    },
});
export default {};
</script>

```
