### PR TITLE
fix:build process

### DIFF
--- a/packages/VueSample/src/pages/VueSample.vue
+++ b/packages/VueSample/src/pages/VueSample.vue
@@ -1,6 +1,6 @@
 <template>
-    <div>
-        <h1>Vue Sample</h1>
+    <div class="vue-sample">
+        <h1>VUE Sample</h1>
         <ul>
             <li v-for="item in items" :key="item.topics_id">
                 {{ item.subject }}
@@ -39,3 +39,11 @@ export default {
     computed: {},
 };
 </script>
+
+<style scoped>
+.vue-sample h1 {
+    font-size: 24px;
+    color: #007bff;
+    margin-bottom: 10px;
+}
+</style>

--- a/packages/VueSample/webpack.config.js
+++ b/packages/VueSample/webpack.config.js
@@ -4,6 +4,9 @@ const { DefinePlugin } = require('webpack');
 const TerserPlugin = require('terser-webpack-plugin');
 const ManifestPlugin = require('webpack-manifest-plugin');
 const VueLoaderPlugin = require('vue-loader/lib/plugin');
+const CleanWebpackPlugin = require('clean-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 
 const config = require('./rcms-js.config.js');
 const pages = require('./pages.config.js');
@@ -47,11 +50,12 @@ module.exports = {
             },
             {
                 test: /\.css$/,
-                use: [
-                    'vue-style-loader', // CSS を JavaScript にインライン化
-                    'css-loader',
-                    'postcss-loader',
-                ],
+                // use: [
+                //     'vue-style-loader', // CSS を JavaScript にインライン化
+                //     'css-loader',
+                //     'postcss-loader',
+                // ],
+                use: [production ? MiniCssExtractPlugin.loader : 'vue-style-loader', 'css-loader', 'postcss-loader'],
             },
             {
                 test: /\.(png|jpe?g|gif|svg|woff2?|eot|ttf|otf)$/,
@@ -68,6 +72,11 @@ module.exports = {
             rcms_js_config: JSON.stringify(config),
         }),
         new VueLoaderPlugin(),
+        new CleanWebpackPlugin(),
+        new ManifestPlugin({ publicPath: '' }),
+        new MiniCssExtractPlugin({
+            filename: serve ? '[name].[hash].css' : '[name].[contenthash].css',
+        }),
         new ManifestPlugin({ publicPath: '' }), // CSS を別ファイルにしない設定
     ],
     optimization: {
@@ -81,6 +90,10 @@ module.exports = {
                         beautify: false,
                     },
                 },
+            }),
+            new OptimizeCSSAssetsPlugin({
+                cssProcessor: require('cssnano'),
+                cssProcessorOptions: { discardComments: { removeAll: true } },
             }),
         ],
         splitChunks: {

--- a/packages/VueSample/webpack.config.js
+++ b/packages/VueSample/webpack.config.js
@@ -50,12 +50,7 @@ module.exports = {
             },
             {
                 test: /\.css$/,
-                // use: [
-                //     'vue-style-loader', // CSS を JavaScript にインライン化
-                //     'css-loader',
-                //     'postcss-loader',
-                // ],
-                use: [production ? MiniCssExtractPlugin.loader : 'vue-style-loader', 'css-loader', 'postcss-loader'],
+                use: [MiniCssExtractPlugin.loader, 'css-loader', 'postcss-loader'],
             },
             {
                 test: /\.(png|jpe?g|gif|svg|woff2?|eot|ttf|otf)$/,
@@ -77,7 +72,6 @@ module.exports = {
         new MiniCssExtractPlugin({
             filename: serve ? '[name].[hash].css' : '[name].[contenthash].css',
         }),
-        new ManifestPlugin({ publicPath: '' }), // CSS を別ファイルにしない設定
     ],
     optimization: {
         minimizer: [
@@ -92,8 +86,10 @@ module.exports = {
                 },
             }),
             new OptimizeCSSAssetsPlugin({
-                cssProcessor: require('cssnano'),
-                cssProcessorOptions: { discardComments: { removeAll: true } },
+                assetNameRegExp: /\.css$/g,
+                cssProcessorOptions: {
+                    discardComments: { removeAll: false },
+                },
             }),
         ],
         splitChunks: {

--- a/packages/VueSample/webpack.config.js
+++ b/packages/VueSample/webpack.config.js
@@ -1,11 +1,8 @@
 const fs = require('fs');
 const path = require('path');
 const { DefinePlugin } = require('webpack');
-const CleanWebpackPlugin = require('clean-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const ManifestPlugin = require('webpack-manifest-plugin');
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const VueLoaderPlugin = require('vue-loader/lib/plugin');
 
 const config = require('./rcms-js.config.js');
@@ -13,8 +10,6 @@ const pages = require('./pages.config.js');
 
 const production = process.env.WEBPACK_MODE === 'production';
 const serve = process.env.WEBPACK_DEV_SERVER;
-
-const eslintNoFail = !production && process.env.RCMS_ESLINT_NO_FAIL_DEV;
 
 const protocol = config.https ? 'https' : 'http';
 
@@ -36,23 +31,27 @@ module.exports = {
                 test: /\.(js|vue)$/,
                 loader: 'eslint-loader',
                 options: {
-                    failOnError: !eslintNoFail,
-                    emitWarning: eslintNoFail,
+                    failOnError: production,
+                    emitWarning: !production,
                 },
                 exclude: /node_modules/,
             },
             {
-                test: /.vue$/,
+                test: /\.vue$/,
                 loader: 'vue-loader',
             },
             {
-                test: /.js$/,
+                test: /\.js$/,
                 exclude: /node_modules/,
                 loader: 'babel-loader',
             },
             {
                 test: /\.css$/,
-                use: [production ? MiniCssExtractPlugin.loader : 'vue-style-loader', 'css-loader', 'postcss-loader'],
+                use: [
+                    'vue-style-loader', // CSS を JavaScript にインライン化
+                    'css-loader',
+                    'postcss-loader',
+                ],
             },
             {
                 test: /\.(png|jpe?g|gif|svg|woff2?|eot|ttf|otf)$/,
@@ -69,11 +68,7 @@ module.exports = {
             rcms_js_config: JSON.stringify(config),
         }),
         new VueLoaderPlugin(),
-        new CleanWebpackPlugin(),
-        new ManifestPlugin({ publicPath: '' }),
-        new MiniCssExtractPlugin({
-            filename: serve ? '[name].[hash].css' : '[name].[contenthash].css',
-        }),
+        new ManifestPlugin({ publicPath: '' }), // CSS を別ファイルにしない設定
     ],
     optimization: {
         minimizer: [
@@ -86,10 +81,6 @@ module.exports = {
                         beautify: false,
                     },
                 },
-            }),
-            new OptimizeCSSAssetsPlugin({
-                cssProcessor: require('cssnano'),
-                cssProcessorOptions: { discardComments: { removeAll: true } },
             }),
         ],
         splitChunks: {


### PR DESCRIPTION
`<style>`を追加した場合に`npm run build`でdistファイルが作成されなかったので修正しました。

## 対応内容

npm run build では production モードが有効になってる。このモードでは optimization.minimizer の設定が使用されるが、ここでエラーが発生し出力が中断されていた
↓
一時的に optimization.minimizer を無効化してビルドできることを確認
```
optimization: {
    // minimizer: [ ... ] // 一時的にコメントアウト
    splitChunks: {
        cacheGroups: {
            commons: {
                test: /[\\/]node_modules[\\/]/,
                name: 'vendors',
                chunks: 'all',
            },
        },
    },
},
```
↓
CSSが別ファイルになるため、
MiniCssExtractPlugin のプラグインを無効化し、代わりに vue-style-loader を使用することで、CSSをJavaScript内にインライン化