### PR TITLE
fix(ChildWysiwyg): update ckfinder script path to version 3.7.0

### DIFF
--- a/packages/ContentsGroupingExtensions/src/components/ChildWysiwyg.vue
+++ b/packages/ContentsGroupingExtensions/src/components/ChildWysiwyg.vue
@@ -20,7 +20,7 @@
                 :delay="0"
                 :lang="siteLang"
                 ckfinder="/management/wysiwyg"
-                script_path="/management/wysiwyg/ckfinder/3.5.1/ckfinder.js"
+                script_path="/management/wysiwyg/ckfinder/3.7.0/ckfinder.js"
             />
         </dd>
     </div>


### PR DESCRIPTION
For GroupingExtensionPlugin.

Using Wysiwyg as an external child library that requires CKFinder version,
it's hardcoded in the plugin.

Found some clients does not work Wysiwyg in management screen.

Seems the version got updated to 3.7.0, removed outdated versions from kuroco-opendev
https://github.com/diverta/Kuroco-opendev/commit/0547235a5cef9e32c6a47c265c51dcc275356427

So that updated from 3.5.1 -> 3.7.0,
Wysiwyg got recovered.