### PR TITLE
issues/55: ChildHtml default width doesn't match the one in regular html extension

### DIFF
--- a/packages/ContentsGroupingExtensions/src/components/ChildHtml.vue
+++ b/packages/ContentsGroupingExtensions/src/components/ChildHtml.vue
@@ -15,8 +15,8 @@
                 :source_id="`code-source--` + $attrs.name"
                 id=""
                 :simplified="true"
-                :width="$attrs.options.width ? $attrs.options.width : '800px'"
-                :height="$attrs.options.height ? $attrs.options.height : '450px'"
+                :width="$attrs.options.width ? $attrs.options.width : '100%'"
+                :height="$attrs.options.height ? $attrs.options.height : '450'"
                 :dont_use_editor="!!$attrs.options.dont_use_editor"
                 :ext_help_msg="$attrs.ext_help_msg"
             />


### PR DESCRIPTION
## Issue
https://github.com/diverta/management-vue-plugin-sample/issues/55

## Reviewer
@nawa-diverta 

## Details of Change
- adjust default ChildHtml width and height to be the same as regular html extension

## Evidence
https://diverta.gyazo.com/73591ca50885d1eac6fba6a3b186870c